### PR TITLE
fixed webpack.config to point to /build/ folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,9 +14,9 @@ module.exports = () => {
       path: path.resolve(__dirname, 'build'),
     },
     devServer: {
-      publicPath: '/client',
+      publicPath: '/build/',
       proxy: {},
-      // hot: true,
+      hot: true,
     },
     plugins: [
       new MiniCssExtractPlugin({


### PR DESCRIPTION
issue: the webpack-dev-server was not loading correctly

solution: we correct the entry point in the webpack.config.js file to point to "/build/" instead of "/client"